### PR TITLE
Add demo dataset with tests

### DIFF
--- a/cmix/data/demo_dataset.py
+++ b/cmix/data/demo_dataset.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from torch.utils.data import Dataset
+import torch
+
+@dataclass
+class DemoDataset(Dataset):
+    """Random dataset with 2-D inputs and 3-D targets."""
+
+    size: int  # number of samples
+
+    def __post_init__(self) -> None:
+        self.x = torch.rand(self.size, 2)
+        self.y = torch.rand(self.size, 3)
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __getitem__(self, idx: int):
+        return self.x[idx], self.y[idx]

--- a/tests/test_demo_dataset.py
+++ b/tests/test_demo_dataset.py
@@ -1,0 +1,23 @@
+import torch
+from torch.utils.data import DataLoader
+from cmix.data.demo_dataset import DemoDataset
+
+
+def test_dataset_shapes():
+    ds = DemoDataset(size=5)
+    assert len(ds) == 5
+    x, y = ds[0]
+    assert x.shape == (2,)
+    assert y.shape == (3,)
+    assert x.dtype == torch.float32
+    assert y.dtype == torch.float32
+    assert torch.all((0 <= x) & (x <= 1))
+    assert torch.all((0 <= y) & (y <= 1))
+
+
+def test_dataloader_batch():
+    ds = DemoDataset(size=8)
+    loader = DataLoader(ds, batch_size=4)
+    x_batch, y_batch = next(iter(loader))
+    assert x_batch.shape == (4, 2)
+    assert y_batch.shape == (4, 3)


### PR DESCRIPTION
## Summary
- add simple `DemoDataset` for randomly generated input/output pairs
- create tests to verify dataset shapes and DataLoader compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687023fe69b8832981af03de6fac2685